### PR TITLE
Fix compilation in Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# ocamlbuild output directory
+/_build
+
+/update_xs_yum.native

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+services:
+  - docker
+
+script:
+  - docker build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 services:
   - docker
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ COPY src/update_xs_yum.ml tmp/src/
 
 WORKDIR tmp/
 
-RUN opam pin add update_xs_yum .
+RUN opam pin add --no-action update_xs_yum .
 
 RUN opam depext -y update_xs_yum
+
+RUN opam install -y update_xs_yum

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ COPY src/update_xs_yum.ml tmp/src/
 
 WORKDIR tmp/
 
+# check the OPAM-related files for errors
+RUN opam lint
+
 RUN opam pin add --no-action update_xs_yum .
 
 RUN opam depext -y update_xs_yum

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ocaml/opam:ubuntu
 RUN mkdir tmp/
 RUN mkdir tmp/src/
 
-COPY opam _tags Makefile tmp/
+COPY opam _tags Makefile update_xs_yum.install tmp/
 COPY src/update_xs_yum.ml tmp/src/
 
 WORKDIR tmp/

--- a/opam
+++ b/opam
@@ -22,6 +22,7 @@ depends: [
   "uri"
   "iso-filesystem"
   "cohttp"
+  "ssl"
   "re"
   "yojson"
 ]

--- a/opam
+++ b/opam
@@ -26,6 +26,7 @@ depends: [
   "yojson"
 ]
 depexts: [
+  [["debian"] ["createrepo" "s3cmd"]]
   [["ubuntu"] ["createrepo" "s3cmd"]]
   [["centos"] ["createrepo" "s3cmd"]]
   [["fedora"] ["createrepo" "s3cmd"]]

--- a/update_xs_yum.install
+++ b/update_xs_yum.install
@@ -1,0 +1,3 @@
+bin: [
+  "_build/src/update_xs_yum.native" {"update_xs_yum"}
+]


### PR DESCRIPTION
Don't install the package immediately when pinning, add the missing "ssl" dependency for HTTPS support, instead of "tls", add Debian `depexts` for using Debian-based containers, add `.install` files for installing the output binary as `update_xs_yum`.

And some little things:
* run "opam lint" while building the Docker image to check the OPAM-related files
* add `.gitignore`
* add `.travis.yml` for testing the build